### PR TITLE
fix bungeecord-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,10 @@
 
     <repositories>
         <repository>
+            <id>bungeecord-repo</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
+        <repository>
             <id>nukkitx-release-repo</id>
             <url>https://repo.nukkitx.com/maven-releases/</url>
             <releases>
@@ -86,7 +90,7 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-api</artifactId>
-            <version>1.15-SNAPSHOT</version>
+            <version>1.16-R0.5-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Maven can now resolve the dependency

Also applies to the floodgate 2.0 branch. I guess merge `master` into `floodgate-2.0` after this?