### PR TITLE
Add server-specific bypass permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ message: "You are not allowed to join that server! :("
 use-floodgate: false
 ```
 
-Any player with the permission `geyserpreventserverswitch.server.bypass` will not be blocked from joining a server.
+Any player with the permission `geyserpreventserverswitch.server.bypass` will not be blocked from joining any server.  
+Additionally, any player with the permision `geyserpreventserverswitch.server.bypass.<servername>` will not be blocked from joining the specified server. 
 
 Discord server: https://discord.gg/jNNC4CZtsN

--- a/src/main/java/com/github/camotoy/geyserpreventserverswitch/Events.java
+++ b/src/main/java/com/github/camotoy/geyserpreventserverswitch/Events.java
@@ -16,7 +16,7 @@ public class Events implements Listener {
     @EventHandler
     public void onServerConnect(ServerConnectEvent event) {
         if (plugin.getProhibitedServers().contains(event.getTarget().getName())) {
-            if (event.getPlayer().hasPermission("geyserpreventserverswitch.server.bypass")) {
+            if (event.getPlayer().hasPermission("geyserpreventserverswitch.server.bypass") || event.getPlayer().hasPermission("geyserpreventserverswitch.server.bypass." + event.getTarget().getName())) {
                 return;
             }
             if (plugin.isBedrockPlayer(event.getPlayer().getUniqueId())) {


### PR DESCRIPTION
This allow bedrock players to join a specific restricted server if they have this permission:

`geyserpreventserverswitch.server.bypass.<servername>` where `<servername>` is the server name defined in bungee's config.yml

I briefly considered renaming `geyserpreventserverswitch.server.bypass` to `geyserpreventserverswitch.server.bypassall` for clarity but realize it would a breaking change.